### PR TITLE
fix: timing error

### DIFF
--- a/src/main/java/org/embeddedt/startuptimer/StartupTimer.java
+++ b/src/main/java/org/embeddedt/startuptimer/StartupTimer.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.awt.*;
+import java.lang.management.ManagementFactory;
 
 @Mod(
         modid = StartupTimer.MOD_ID,
@@ -30,7 +31,7 @@ public class StartupTimer {
     public static StartupTimer INSTANCE;
 
     public static long doneTime = 0;
-    public static long startupInstant = System.currentTimeMillis();
+    public static long startupInstant = ManagementFactory.getRuntimeMXBean().getStartTime();
 
     boolean triggered = false;
     boolean trueFullscreen;

--- a/src/main/java/org/embeddedt/startuptimer/StartupTimer.java
+++ b/src/main/java/org/embeddedt/startuptimer/StartupTimer.java
@@ -1,25 +1,17 @@
 package org.embeddedt.startuptimer;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiMainMenu;
-import net.minecraft.client.gui.ScaledResolution;
-import net.minecraft.item.Item;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.awt.*;
-import java.lang.management.ManagementFactory;
 
 @Mod(
         modid = StartupTimer.MOD_ID,
@@ -38,6 +30,7 @@ public class StartupTimer {
     public static StartupTimer INSTANCE;
 
     public static long doneTime = 0;
+    public static long startupInstant = System.currentTimeMillis();
 
     boolean triggered = false;
     boolean trueFullscreen;
@@ -67,7 +60,7 @@ public class StartupTimer {
                 Minecraft.getMinecraft().gameSettings.fullScreen = Minecraft.getMinecraft().isFullScreen();
             }
 
-            startupTime = ManagementFactory.getRuntimeMXBean().getUptime();
+            startupTime = System.currentTimeMillis() - startupInstant;
             LOGGER.info("Startup took " + startupTime + "ms.");
 
             doneTime = startupTime;

--- a/src/main/java/org/embeddedt/startuptimer/mixin/SplashProgressMixin.java
+++ b/src/main/java/org/embeddedt/startuptimer/mixin/SplashProgressMixin.java
@@ -1,8 +1,5 @@
 package org.embeddedt.startuptimer.mixin;
 
-import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL12.*;
-
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraftforge.fml.client.SplashProgress;
 import org.embeddedt.startuptimer.StartupTimer;
@@ -15,8 +12,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
+
+import static org.lwjgl.opengl.GL11.*;
 
 @Mixin(targets = { "net/minecraftforge/fml/client/SplashProgress$2" })
 public abstract class SplashProgressMixin {
@@ -58,8 +56,7 @@ public abstract class SplashProgressMixin {
      * Get formatted timer + estimate string
      */
     private String getString(){
-        long startupTime = ManagementFactory.getRuntimeMXBean().getUptime();
-
+        long startupTime = System.currentTimeMillis() - StartupTimer.startupInstant;
         if(StartupTimer.doneTime > 0) startupTime = StartupTimer.doneTime;
 
         long minutes = (startupTime / 1000) / 60;


### PR DESCRIPTION
When timing, for example, if the main thread gets stuck at ten seconds and resumes after five seconds, the timer will continue counting from 10 seconds instead of 15 seconds.

So I subtracted the starting timestamp from the current timestamp, obtained the timestamp difference, and then converted it to time to solve this problem.